### PR TITLE
remove dummy test file as it is no longer needed

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,2 +1,0 @@
-def test_nothing() -> None:
-    assert True


### PR DESCRIPTION
This PR removes the test_basic.py file, as it was only there initially so that pytest did not complain in CI about finding no tests.

Since there is now a test for the logger module, this is no longer required.