### PR TITLE
Update header links

### DIFF
--- a/pulse/templates/includes/header.html
+++ b/pulse/templates/includes/header.html
@@ -35,13 +35,10 @@
     <nav class="bg-grey-light">
     	<div class="container mx-auto flex">
     		<div class="flex-1">
-    			<h2 class="py-6 text-xl">HTTPS Everywhere</h2>
+    			<h2 class="py-6 text-xl"><a class="underline text-black" href="/">HTTPS Everywhere</a></h2>
     		</div>
 	        <div role="navigation" class="flex-1">
 	            <ul class="list-reset flex justify-end text-xl font-bold">
-	                <li class="mr-8 py-6 px-2">
-	                    <a class="text-blue hover:text-blue-darker" href="#">Home</a>
-	                </li>
 	                <li class="mr-8 py-6 px-2">
 	                    <a class="text-blue hover:text-blue-darker" href="#">About</a>
 	                </li>


### PR DESCRIPTION
This PR fixes a mistake I made in the original header creation. Removed the "Home" link and turned the title into the link back to home. Never trust developers with your designs @samsadasivan 