### PR TITLE
correctly get the data directory 

### DIFF
--- a/data/cli.py
+++ b/data/cli.py
@@ -4,6 +4,7 @@ import datetime
 import click
 import ujson
 from data.env import PARENTS_RESULTS
+from data.env import DATA_DIR
 from data import update as data_update
 from data import processing
 from data import logger
@@ -38,11 +39,7 @@ def get_date(
         param: typing.Optional[click.core.Option],  # pylint: disable=unused-argument
         value: typing.Optional[str],
     ) -> str:
-
-    # Date can be overridden if need be, but defaults to meta.json.
-    directory, _ = os.path.split(__file__)
-
-    return value if value is not None else get_cached_date(directory)
+    return value if value is not None else get_cached_date(DATA_DIR)
 
 
 # Convert ["--option", "value", ... ] to {"option": "value", ...}

--- a/data/env.py
+++ b/data/env.py
@@ -3,7 +3,7 @@ import pkg_resources
 import sys
 import yaml
 
-DATA_DIR = os.path.dirname(__file__)
+DATA_DIR = os.path.join(os.getcwd(), 'data')
 
 # App-level metadata.
 _resource_package = __name__


### PR DESCRIPTION
This PR is to correct an oversight when determining `DATA_DIR`, as it should be based on working directory, not directory of installed `env.py` file