### PR TITLE
Mobile style improvements

### DIFF
--- a/pulse/pulse/templates/domains.html
+++ b/pulse/pulse/templates/domains.html
@@ -2,7 +2,8 @@
 
 {% block title %}HTTPS Everywhere{% endblock %}
 
-{% block page_header %}
+{% block content %}
+<header class="bg-grey-lighter py-6">
 
 	{% include 'includes/https/header.html' %}
 
@@ -10,9 +11,7 @@
 		<p class="uppercase"><a href="/" class="mr-8 text-blue hover:text-blue-darker">by organization</a> by domain</a></p>
 	</div>
 
-{% endblock %}
-
-{% block content %}
+</header>
 
 <section id="main-content">
 
@@ -37,5 +36,4 @@
 </section>
 
 <script src="/static/js/https/domains.js?{{ now() | date("%Y%m%j%H%M%S") }}"></script> 
-
 {% endblock %}

--- a/pulse/pulse/templates/includes/footer.html
+++ b/pulse/pulse/templates/includes/footer.html
@@ -1,10 +1,12 @@
 <footer id="goc-footer" class="bg-black">
-    <div class="container mx-auto flex">
-        <ul class="list-reset">
-            <li class="py-2"><a href="" class="text-white">Privacy</a></li>
-            <li class="py-2"><a href="" class="text-white">Terms & Conditions</a></li>
-        </ul>
-        <div class="flex-1 text-right min-width-full">
+    <div class="flex flex-col-reverse sm:flex-row container mx-auto">
+    	<div class="flex-1">
+	        <ul class="list-reset flex justify-center sm:justify-start">
+	            <li class="py-2"><a href="" class="text-white">Privacy</a></li>
+	            <li class="py-2"><a href="" class="text-white">Terms & Conditions</a></li>
+	        </ul>
+	    </div>
+        <div class="flex-1 text-center sm:text-right min-width-full mb-2 sm:mb-0">
             <object class="h-10" type="image/svg+xml" tabindex="-1" role="img" data="/static/images/wordmark-dark.svg" aria-label="Symbol of the Government of Canada"></object>
         </div>
     </div>

--- a/pulse/pulse/templates/includes/header.html
+++ b/pulse/pulse/templates/includes/header.html
@@ -3,7 +3,7 @@
 
     <!-- Alpha bar -->
 
-    <section class="bg-grey-darkest py-4 text-sm sm:block md:block lg:block xl:block">
+    <section class="bg-grey-darkest py-4 text-xs sm:text-sm sm:block md:block lg:block xl:block">
         <div class="container mx-auto text-white flex items-center">
             <span class="flex-initial">
                 <span class="bg-blue-dark py-2 px-4 rounded uppercase mr-4">Alpha</span>
@@ -23,7 +23,7 @@
                 </a>
             </div>
 
-            <div class="flex-1 text-right pt-2 pb-2">
+            <div class="flex-1 text-right pt-2 pb-2 hidden sm:inline">
                 <h2 class="sr-only">Language selection</h2>
                 <a href="" class="text-white" lang="fr">Français</a>
             </div>
@@ -35,14 +35,17 @@
     <nav class="bg-grey-light">
     	<div class="container mx-auto flex">
     		<div class="flex-1">
-    			<h2 class="py-6 text-xl"><a class="underline text-black" href="/">HTTPS Everywhere</a></h2>
+    			<h2 class="py-6 text-lg sm:text-xl"><a class="underline text-black" href="/">HTTPS Everywhere</a></h2>
     		</div>
 	        <div role="navigation" class="flex-1">
-	            <ul class="list-reset flex justify-end text-xl font-bold">
-	                <li class="mr-8 py-6 px-2">
+	            <ul class="list-reset flex justify-end text-lg sm:text-xl font-bold">
+                    <li class="py-6 inline sm:hidden">
+                        <a class="text-blue hover:text-blue-darker" href="#">Menu</a>
+                    </li>
+	                <li class="mr-8 py-6 px-2 hidden sm:inline">
 	                    <a class="text-blue hover:text-blue-darker" href="#">About</a>
 	                </li>
-	                <li class="py-6">
+	                <li class="py-6 hidden sm:inline">
 	                    <a class="text-blue hover:text-blue-darker" href="#">Feedback</a>
 	                </li>
 	            </ul>

--- a/pulse/pulse/templates/includes/https/donut.html
+++ b/pulse/pulse/templates/includes/https/donut.html
@@ -4,7 +4,7 @@ function generate_chart(chart_class) {
     var elem = chart[0][0];
     var width = chart.attr("data-width");
     if (width == null)
-        width = getComputedStyle(elem.parentElement).width;
+        width = calculate_width();
     width = parseInt(width);
     var height = width * 1.2;
     var radius = Math.min(width, height) / 2;
@@ -70,7 +70,7 @@ function generate_chart(chart_class) {
 function calculate_width() {
     window_width = $(window).width();
 
-    if(window_width < 500)
+    if(window_width < 769)
         return 250;
     else
         return 287;

--- a/pulse/pulse/templates/includes/https/donut.html
+++ b/pulse/pulse/templates/includes/https/donut.html
@@ -67,6 +67,15 @@ function generate_chart(chart_class) {
     });
 };
 
+function calculate_width() {
+    window_width = $(window).width();
+
+    if(window_width < 500)
+        return 250;
+    else
+        return 287;
+}
+
 generate_chart(".https_chart")
 
 generate_chart(".hsts_chart")

--- a/pulse/pulse/templates/includes/https/header.html
+++ b/pulse/pulse/templates/includes/https/header.html
@@ -1,16 +1,16 @@
 <div class="container mx-auto items-center sm:w-4/5 xl:w-3/5">
-	<h1>HTTPS</h1>
-	<h2 class="mb-6">Last updated April 16, 2018</h2>
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vestibulum.</p>
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu dolor eget eros consequat congue. Nunc congue arcu imperdiet metus.</p>
+	<h1 class="text-4xl sm:text-5xl">HTTPS</h1>
+	<h2 class="mb-4 sm:mb-6 text-xl sm:text-2xl">Last updated April 16, 2018</h2>
+	<p class="text-base sm:text-lg">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vestibulum.</p>
+	<p class="text-base sm:text-lg">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu dolor eget eros consequat congue. Nunc congue arcu imperdiet metus.</p>
 
 	<div class="flex flex-col justify-center md:flex-row lg:flex-row xl:flex-row mt-6 mx-auto xl:w-5/6">
 		<div class="flex-1 items-center text-center md:mr-8">
-			<h3 class="font-bold text-2xl">HTTPS Enforced</h3>
+			<h3 class="font-bold text-xl sm:text-2xl">HTTPS Enforced</h3>
 			<div class="https_chart"></div>
 		</div>
 		<div class="flex-1 items-center text-center md:ml-8">
-			<h3 class="font-bold text-2xl">HSTS</h3>
+			<h3 class="font-bold text-xl sm:text-2xl">HSTS</h3>
 			<div class="hsts_chart"></div>
 		</div>
 			{% include 'includes/https/donut.html' %}

--- a/pulse/pulse/templates/includes/https/header.html
+++ b/pulse/pulse/templates/includes/https/header.html
@@ -1,15 +1,15 @@
-<div class="container mx-auto items-center sm:w-4/5 lg:w-3/5">
+<div class="container mx-auto items-center sm:w-4/5 xl:w-3/5">
 	<h1>HTTPS</h1>
 	<h2 class="mb-6">Last updated April 16, 2018</h2>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vestibulum.</p>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu dolor eget eros consequat congue. Nunc congue arcu imperdiet metus.</p>
 
-	<div class="flex flex-col justify-center md:flex-row lg:flex-row xl:flex-row mt-6">
-		<div class="flex-1 items-center text-center md:mr-8 xl:mr-0">
+	<div class="flex flex-col justify-center md:flex-row lg:flex-row xl:flex-row mt-6 mx-auto xl:w-5/6">
+		<div class="flex-1 items-center text-center md:mr-8">
 			<h3 class="font-bold text-2xl">HTTPS Enforced</h3>
 			<div class="https_chart"></div>
 		</div>
-		<div class="flex-1 items-center text-center">
+		<div class="flex-1 items-center text-center md:ml-8">
 			<h3 class="font-bold text-2xl">HSTS</h3>
 			<div class="hsts_chart"></div>
 		</div>

--- a/pulse/pulse/templates/includes/https/header.html
+++ b/pulse/pulse/templates/includes/https/header.html
@@ -4,14 +4,14 @@
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vestibulum.</p>
 	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu dolor eget eros consequat congue. Nunc congue arcu imperdiet metus.</p>
 
-	<div class="flex justify-center sm:flex-col md:flex-row lg:flex-row xl:flex-row mt-6">
-		<div class="flex-1 items-center text-center">
+	<div class="flex flex-col justify-center md:flex-row lg:flex-row xl:flex-row mt-6">
+		<div class="flex-1 items-center text-center md:mr-8 xl:mr-0">
 			<h3 class="font-bold text-2xl">HTTPS Enforced</h3>
-			<div class="https_chart" data-width="287"></div>
+			<div class="https_chart"></div>
 		</div>
 		<div class="flex-1 items-center text-center">
 			<h3 class="font-bold text-2xl">HSTS</h3>
-			<div class="hsts_chart" data-width="287"></div>
+			<div class="hsts_chart"></div>
 		</div>
 			{% include 'includes/https/donut.html' %}
 	</div>

--- a/pulse/pulse/templates/index.html
+++ b/pulse/pulse/templates/index.html
@@ -2,7 +2,8 @@
 
 {% block title %}HTTPS Everywhere{% endblock %}
 
-{% block page_header %}
+{% block content %}
+<header class="bg-grey-lighter py-6">
 
 	{% include 'includes/https/header.html' %}
 
@@ -10,9 +11,7 @@
 		<p class="uppercase">by organization <a href="/domains/" class="ml-8 text-blue hover:text-blue-darker">by domain</a></p>
 	</div>
 
-{% endblock %}
-
-{% block content %}
+</header>
 
 <section id="main-content">
 

--- a/pulse/pulse/templates/layout-en.html
+++ b/pulse/pulse/templates/layout-en.html
@@ -6,6 +6,7 @@
 	<title>{% block title %}{% endblock title %}</title>
 	
 	{% include 'includes/head.html' %}
+	
 </head>
 
 <body>
@@ -13,12 +14,6 @@
 	{% include 'includes/header.html' %}
 
 	<main>
-
-		<header class="bg-grey-lighter py-6">
-
-			{% block page_header %}{% endblock %}
-
-		</header>
 
 		{% block content %}{% endblock %}
 


### PR DESCRIPTION
This PR improves the styling of our version of Pulse on mobile! Notable changes:

- Changed the donut script to select the width of the donut on render, based on the size of the screen. Basically if the size is medium or under, render the circles slightly smaller. This improves the overall 
look.
- Made some changes to container sizing to improve large & extra large views

- Created a mobile style for the header. On small screens it'll now look like this: 
<img width="412" alt="screen shot 2018-05-16 at 10 52 41 am" src="https://user-images.githubusercontent.com/1545806/40124816-5b7b82a8-58f7-11e8-8e70-2c01aa1b1fd9.png">

- A pop out menu will be added in a future PR. The language switch link will be added to this menu. 

- Created a mobile style for the footer. On small screens it'll now look like this:
<img width="258" alt="screen shot 2018-05-16 at 10 43 59 am" src="https://user-images.githubusercontent.com/1545806/40124975-ba21a1ca-58f7-11e8-8b48-246dc15c80a8.png">

