### PR TITLE
ignore _id field

### DIFF
--- a/pulse_update/data/processing.py
+++ b/pulse_update/data/processing.py
@@ -534,7 +534,6 @@ def full_report(domains, subdomains):
 
     return full
 
-
 def eligible_for_https(domain):
     return domain["live"] == True
 
@@ -653,6 +652,7 @@ def https_behavior_for(name, pshtt, sslyze, parent_preloaded=None):
 
     # values: unknown or N/A (-1), No (0), Yes (1)
     bod_crypto = None
+
 
     # N/A if no HTTPS
     if report["uses"] <= 0:
@@ -799,7 +799,7 @@ def total_preloading_report(eligible):
 def print_report(report):
 
     for report_type in report.keys():
-        if report_type == "report_date":
+        if report_type == "report_date" or report_try == "_id":
             continue
 
         LOGGER.info("[%s]" % report_type)

--- a/pulse_update/data/processing.py
+++ b/pulse_update/data/processing.py
@@ -799,7 +799,7 @@ def total_preloading_report(eligible):
 def print_report(report):
 
     for report_type in report.keys():
-        if report_type == "report_date" or report_try == "_id":
+        if report_type == "report_date" or report_type == "_id":
             continue
 
         LOGGER.info("[%s]" % report_type)


### PR DESCRIPTION
With the switch to pymongo we have to contend with an annoying feature on it's insert method, the fact that it mutates the input dictionary to contain an `_id` field. The only ways of preventing this behavior is to already have an `_id` field on the object, or to insert a copy (which would be quite slow).

I would prefer not to have to modify the client code to reflect the switch to mongo, but at least temporarily this is the best solution to the problems this behavior causes.