### PR TITLE
Add scan dockerfile

### DIFF
--- a/pulse_update/Dockerfile.run
+++ b/pulse_update/Dockerfile.run
@@ -1,0 +1,29 @@
+FROM python:3.6
+MAINTAINER David Buckley <david.buckley@cds-snc.ca>
+LABEL Description="HTTPS Everywhere Scanner Application" Vendor="Canadian Digital Service"
+
+RUN pip install awscli
+
+ENV DOMAIN_HOME /opt/scan/domain-scan
+ENV PULSE_HOME /opt/scan/pulse
+ENV DOMAIN_SCAN_PATH $DOMAIN_HOME/scan
+ENV DOMAIN_GATHER_PATH $DOMAIN_HOME/gather
+
+# Pull down the domain-scan repo to /opt/scan/domain-scan
+RUN mkdir -p $DOMAIN_HOME && wget -q -O - https://api.github.com/repos/cds-snc/domain-scan/tarball | tar xz --strip-components=1 -C $DOMAIN_HOME
+
+COPY deploy/scan.sh $PULSE_HOME/deploy/scan.sh
+RUN chmod +x $PULSE_HOME/deploy/scan.sh
+
+# Copy required source and package files
+COPY MANIFEST.in $PULSE_HOME/MANIFEST.in
+COPY setup.py $PULSE_HOME/setup.py 
+COPY data $PULSE_HOME/data
+
+# Setup environment
+RUN pip install $PULSE_HOME/.
+RUN pip install -r $DOMAIN_HOME/requirements.txt
+RUN pip install -r $DOMAIN_HOME/requirements-scanners.txt
+
+# Set entrypoint
+ENTRYPOINT $PULSE_HOME/deploy/scan.sh

--- a/pulse_update/deploy/scan.sh
+++ b/pulse_update/deploy/scan.sh
@@ -1,0 +1,22 @@
+printf "STARTING INIT CONTAINER\n"
+
+# Make sure that AWS credentials have been configured
+mkdir -p ~/.aws
+cat > ~/.aws/credentials << EOF
+[lambda]
+aws_access_key_id=$PULSE_AWS_KEY_ID
+aws_secret_access_key=$PULSE_AWS_SECRET
+EOF 
+
+printf "Created aws credentials\n"
+cat > ~/.aws/config << EOF
+[profile lambda]
+region=$PULSE_AWS_REGION
+output=json
+EOF
+
+printf "Created aws configuration\n"
+
+cd $PULSE_HOME
+pulse preprocess
+pulse run --scan here ${PULSE_AWS_SECRET+"--lambda --lambda-profile lambda"}


### PR DESCRIPTION
This PR adds a dockerfile for a container that simply runs a scan when spun up, then exits.

It might be helpful to work out mounting a persistent volume onto this dockerfile to cache some downloaded data (like the public suffix list) that is used in the process of the computations. However that can be added later. 