### PR TITLE
I18n tables

### DIFF
--- a/pulse/pulse/static/js/dataTables.downloads.js
+++ b/pulse/pulse/static/js/dataTables.downloads.js
@@ -20,7 +20,7 @@ $.fn.dataTable.Download = function ( inst ) {
   var container = $('<div></div>').addClass( 'dataTables_csv' );
   var drawnOnce = false;
 
-  var language = $( "#data_table" ).attr("language");
+  var language = $( "#data-table" ).attr("language");
 
   if(language == 'en')
     var text = "Download as CSV"

--- a/pulse/pulse/static/js/dataTables.downloads.js
+++ b/pulse/pulse/static/js/dataTables.downloads.js
@@ -20,6 +20,13 @@ $.fn.dataTable.Download = function ( inst ) {
   var container = $('<div></div>').addClass( 'dataTables_csv' );
   var drawnOnce = false;
 
+  var language = $( "#data_table" ).attr("language");
+
+  if(language == 'en')
+    var text = "Download as CSV"
+  else
+    var text = "Télécharger en tant que fichier CSV"
+
   // API so the feature wrapper can return the node to insert
   this.container = function () {
     return container[0];
@@ -30,7 +37,7 @@ $.fn.dataTable.Download = function ( inst ) {
 
     var elem = "" +
       "<a class=\"text-blue hover:text-blue-darker font-bold\" href=\"" + csv + "\" download>" +
-        "Download as CSV" +
+        text +
       "</a>";
 
     container.html(elem);

--- a/pulse/pulse/static/js/https/domains.js
+++ b/pulse/pulse/static/js/https/domains.js
@@ -177,7 +177,7 @@ $(function () {
         2: "<strong>Yes</strong>"  // Yes
       },
       fr: {
-        0: "Oui", 
+        0: "Non", 
         1: "Prêt", 
         2: "<strong>Yes</strong>"
       }

--- a/pulse/pulse/static/js/https/domains.js
+++ b/pulse/pulse/static/js/https/domains.js
@@ -53,7 +53,7 @@ $(function () {
         },
         {
           data: "https.preloaded",
-          render: display(names.preloaded)
+          render: display(names.preloaded[language])
         },
         {
           data: "",
@@ -95,36 +95,92 @@ $(function () {
       fr: "détails"
     },
 
+    preloaded: {
+      en: "No, uses",
+      fr: "Non, utilise"
+    },
+
+    link_1: {
+      en: "Showing data for ",
+      fr: "Afficher les données pour "
+    },
+
+    link_2: {
+      en: " publicly discoverable services within ",
+      fr: " services publiquement repérables dans "
+    },
+
+    link_3: {
+      en: "Download all ",
+      fr: "Télécharger toutes les données "
+    },
+
+    link_4: {
+      en: " data as a CSV",
+      fr: " sous forme de fichier CSV."
+    },
+
   };
 
   var names = {
 
     enforces: {
-      0: "No", // No (no HTTPS)
-      1: "No", // Present, not default
-      2: "Yes", // Defaults eventually to HTTPS
-      3: "Yes" // Defaults eventually + redirects immediately
+      en: {
+        0: "No", // No (no HTTPS)
+        1: "No", // Present, not default
+        2: "Yes", // Defaults eventually to HTTPS
+        3: "Yes" // Defaults eventually + redirects immediately
+      },
+      fr: {
+        0: "Non", 
+        1: "Non", 
+        2: "Oui", 
+        3: "Oui" 
+      },
     },
 
     hsts: {
-      "-1": "No", // No (no HTTPS)
-      0: "No",  // No
-      1: "No", // No, HSTS with short max-age (for canonical endpoint)
-      2: "Yes", // Yes, HSTS for >= 1 year (for canonical endpoint)
-      3: "Preloaded" // Yes, via preloading (subdomains only)
+      en: {
+        "-1": "No", // No (no HTTPS)
+        0: "No",  // No
+        1: "No", // No, HSTS with short max-age (for canonical endpoint)
+        2: "Yes", // Yes, HSTS for >= 1 year (for canonical endpoint)
+        3: "Preloaded" // Yes, via preloading (subdomains only)
+      },
+      fr: {
+        "-1": "Non", 
+        0: "Non",
+        1: "Non",
+        2: "Oui",
+        3: "Préchargé"
+      }
     },
 
     bod_crypto: {
-      "-1": "--", // No HTTPS
-      0: "No",
-      1: "Yes"
+      en: {
+        "-1": "--", // No HTTPS
+        0: "No",
+        1: "Yes"
+      },
+      fr: {
+        "-1": "--",
+        0: "Non",
+        1: "Oui"
+      }
     },
 
     // Parent domains only
     preloaded: {
-      0: "No",  // No
-      1: "Ready",  // Preload-ready
-      2: "<strong>Yes</strong>"  // Yes
+      en: {
+        0: "No",  // No
+        1: "Ready",  // Preload-ready
+        2: "<strong>Yes</strong>"  // Yes
+      },
+      fr: {
+        0: "Oui", 
+        1: "Prêt", 
+        2: "<strong>Yes</strong>"
+      }
     },
 
   };
@@ -141,7 +197,7 @@ $(function () {
   var displayCrypto = function(row) {
     // if it's all good, then great
     if (row.https.bod_crypto != 0)
-      return names.bod_crypto[row.https.bod_crypto];
+      return names.bod_crypto[language][row.https.bod_crypto];
 
     var problems = [];
     // if not, what are the problems?
@@ -150,7 +206,7 @@ $(function () {
     if (row.https.sslv2) problems.push("SSLv2");
     if (row.https.sslv3) problems.push("SSLv3");
 
-    return "No, uses " + problems.join(", ");
+    return text.preloaded[language] + problems.join(", ");
   };
 
   var loadHostData = function(tr, base_domain, hosts) {
@@ -160,14 +216,8 @@ $(function () {
     if (number > 1) {
       var csv = "/data/hosts/" + base_domain + "/https.csv";
 
-      if (language == 'en') {
-        var link = "Showing data for " + number + " publicly discoverable services within " + base_domain + ".&nbsp;&nbsp;";
-        link += l(csv, "Download all " + base_domain + " data as a CSV") + ".";
-      }
-      else {
-        var link = "Afficher les données pour " + number + " services publiquement repérables dans " + base_domain + ".&nbsp;&nbsp;";
-        link += l(csv, "Télécharger toutes les données " + base_domain + " sous forme de fichier CSV.") + ".";
-      }
+      var link = text.link_1[language] + number + text.link_2[language] + base_domain + ".&nbsp;&nbsp;";
+      link += l(csv, text.link_3[language] + base_domain + text.link_4[language]) + ".";
 
       var download = $("<tr></tr>").addClass("subdomain").html("<td class=\"link\" colspan=6>" + link + "</td>");
       all.push(download);
@@ -180,10 +230,10 @@ $(function () {
       var link = "<a href=\"" + host.canonical + "\" target=\"blank\">" + Utils.truncate(host.domain, 35) + "</a>";
       details.append($("<td/>").addClass("link").html(link));
 
-      var https = names.enforces[host.https.enforces];
+      var https = names.enforces[language][host.https.enforces];
       details.append($("<td class=\"compliant\"/>").html(https));
 
-      var hsts = names.hsts[host.https.hsts];
+      var hsts = names.hsts[language][host.https.hsts];
       details.append($("<td/>").html(hsts));
 
       var crypto = displayCrypto(host);

--- a/pulse/pulse/static/js/https/domains.js
+++ b/pulse/pulse/static/js/https/domains.js
@@ -18,6 +18,8 @@ $(function () {
 
       initComplete: initExpansions,
 
+      prefix: language,
+
       columns: [
         {
           className: 'control',
@@ -36,7 +38,7 @@ $(function () {
             td.scope = "row";
           }
         },
-        {data: "organization_name_en"}, // here for filtering/sorting
+        {data: "organization_name_" + language}, // here for filtering/sorting
         {
           data: "totals.https.enforces",
           render: Tables.percentTotals("https", "enforces")
@@ -60,6 +62,9 @@ $(function () {
       ]
     });
   });
+
+  //get table language
+  var language = $( "#data-table" ).attr("language");
 
   /**
   * I don't like this at all, but to keep the presentation synced

--- a/pulse/pulse/static/js/https/domains.js
+++ b/pulse/pulse/static/js/https/domains.js
@@ -120,6 +120,21 @@ $(function () {
       fr: " sous forme de fichier CSV."
     },
 
+    fetch: {
+      en: "Fetching data for ",
+      fr: "Récupération des données de "
+    },
+
+    loading: {
+      en: "Loading ",
+      fr: "Téléchargement des "
+    },
+
+    error: {
+      en: "Error loading data for ",
+      fr: "Erreur dans le téléchargement des données de "
+    }
+
   };
 
   var names = {
@@ -289,8 +304,8 @@ $(function () {
         var fetch = link.data("fetch");
 
         if (fetch) {
-          console.log("Fetching data for " + base_domain + "...");
-          link.addClass("loading").html("Loading " + base_domain + " services...");
+          console.log(text.fetch[language] + base_domain + "...");
+          link.addClass("loading").html(text.loading[language] + base_domain + " services...");
 
           $.ajax({
             url: "/data/hosts/" + base_domain + "/https.json" + Utils.cacheBust(),
@@ -310,7 +325,7 @@ $(function () {
               link.html(showHideText(false, data));
             },
             error: function() {
-              console.log("Error loading data for " + base_domain);
+              console.log(text.error[language] + base_domain);
             }
           });
         } else {

--- a/pulse/pulse/static/js/https/domains.js
+++ b/pulse/pulse/static/js/https/domains.js
@@ -76,6 +76,27 @@ $(function () {
   * a cleaner way to DRY (don't repeat yourself) this mess up.
   */
 
+  // todo: add french names
+
+  var text = {
+
+    show: {
+      en: "Show",
+      fr: "Montrer les"
+    } , 
+
+    hide: {
+      en: "Hide",
+      fr: "Cacher les"
+    },
+
+    details: {
+      en: "details",
+      fr: "détails"
+    },
+
+  };
+
   var names = {
 
     enforces: {
@@ -138,10 +159,16 @@ $(function () {
 
     if (number > 1) {
       var csv = "/data/hosts/" + base_domain + "/https.csv";
-      //var discoveryLink = l("/https/guidance/#subdomains", "publicly discoverable services");
-      var link = "Showing data for " + number + " publicly discoverable services within " + base_domain + ".&nbsp;&nbsp;";
-      link += l(csv, "Download all " + base_domain + " data as a CSV") + ".";
-      link += " Email " + l("mailto:zzTBSCybers@tbs-sct.gc.ca", "zzTBSCybers@tbs-sct.gc.ca") + " with questions.";
+
+      if (language == 'en') {
+        var link = "Showing data for " + number + " publicly discoverable services within " + base_domain + ".&nbsp;&nbsp;";
+        link += l(csv, "Download all " + base_domain + " data as a CSV") + ".";
+      }
+      else {
+        var link = "Afficher les données pour " + number + " services publiquement repérables dans " + base_domain + ".&nbsp;&nbsp;";
+        link += l(csv, "Télécharger toutes les données " + base_domain + " sous forme de fichier CSV.") + ".";
+      }
+
       var download = $("<tr></tr>").addClass("subdomain").html("<td class=\"link\" colspan=6>" + link + "</td>");
       all.push(download);
     }
@@ -186,9 +213,9 @@ $(function () {
 
   var showHideText = function(show, row) {
     if (loneDomain(row))
-      return (show ? "show" : "hide") + " details";
+      return (show ? text.show[language] : text.hide[language]) + " " + text.details[language];
     else
-      return (show ? "show" : "hide") + " " + row.totals.https.eligible + " services";
+      return (show ? text.show[language] : text.hide[language]) + " " + row.totals.https.eligible + " services";
   };
 
   var initExpansions = function() {

--- a/pulse/pulse/static/js/https/organizations.js
+++ b/pulse/pulse/static/js/https/organizations.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
 
       csv: "/data/hosts/https.csv",
 
-      prefix: getLanguage(),
+      prefix: language,
 
       columns: [
         {
@@ -17,7 +17,7 @@ $(document).ready(function () {
           visible: false
         },
         {
-          data: "name_" + getLanguage(),
+          data: "name_" + language,
           cellType: "td",
           render: eligibleHttps,
           createdCell: function (td) {td.scope = "row";}
@@ -43,16 +43,12 @@ $(document).ready(function () {
     });
   });
 
-  var getLanguage = function() {
-    var prefix = $( "#data_table" ).attr("language");
-    if(prefix == 'en' || prefix == 'fr') return prefix;
-    else return 'en';
-  }
+  //get table language
+  var language = $( "#data-table" ).attr("language");
 
   var eligibleHttps = function(data, type, row) {
     var services = row.https.eligible;
     var domains = row.total_domains;
-    var language = getLanguage();
 
     if(language == 'en') {
       var name = row.name_en;

--- a/pulse/pulse/static/js/https/organizations.js
+++ b/pulse/pulse/static/js/https/organizations.js
@@ -6,6 +6,8 @@ $(document).ready(function () {
 
       csv: "/data/hosts/https.csv",
 
+      prefix: getLanguage(),
+
       columns: [
         {
           className: 'control',
@@ -52,10 +54,14 @@ $(document).ready(function () {
     var domains = row.total_domains;
     var language = getLanguage();
 
-    if(language == 'en') 
+    if(language == 'en') {
       var name = row.name_en;
-    else
+      var link_text = "Show";
+    }
+    else {
       var name = row.name_fr;
+      var link_text = "Montrer";
+    }
 
     var services_text = "service";
     if (type == "sort") return name;
@@ -65,13 +71,14 @@ $(document).ready(function () {
 
     var link = function(text) {
       return "" +
-        "<a href=\"/en/domains/#" +
-          QueryString.stringify({q: row["name_en"]}) + "\">" +
+        "<a href=\"/" + language + "/domains/#" +
+          QueryString.stringify({q: row["name_" + language]}) + "\">" +
            text +
         "</a>";
     }
 
-    return "<div class=\"mb-2\">" + name + "</div>" + link("Show " + services + " " + services_text);
+
+    return "<div class=\"mb-2\">" + name + "</div>" + link(link_text + " " + services + " " + services_text);
 
   };
 

--- a/pulse/pulse/static/js/https/organizations.js
+++ b/pulse/pulse/static/js/https/organizations.js
@@ -1,6 +1,7 @@
 $(document).ready(function () {
 
   $.get("/data/organizations/https.json", function(data) {
+
     Tables.initAgency(data.data, {
 
       csv: "/data/hosts/https.csv",
@@ -14,7 +15,7 @@ $(document).ready(function () {
           visible: false
         },
         {
-          data: "name_en",
+          data: "name_" + getLanguage(),
           cellType: "td",
           render: eligibleHttps,
           createdCell: function (td) {td.scope = "row";}
@@ -40,10 +41,22 @@ $(document).ready(function () {
     });
   });
 
+  var getLanguage = function() {
+    var prefix = $( "#data_table" ).attr("language");
+    if(prefix == 'en' || prefix == 'fr') return prefix;
+    else return 'en';
+  }
+
   var eligibleHttps = function(data, type, row) {
     var services = row.https.eligible;
     var domains = row.total_domains;
-    var name = row.name_en;
+    var language = getLanguage();
+
+    if(language == 'en') 
+      var name = row.name_en;
+    else
+      var name = row.name_fr;
+
     var services_text = "service";
     if (type == "sort") return name;
 

--- a/pulse/pulse/static/js/tables.js
+++ b/pulse/pulse/static/js/tables.js
@@ -16,13 +16,39 @@ var Tables = {
       customInit(this);
     }
 
-    if (!options.oLanguage) {
+    // If the table prefix is french, load french translations
+    if (options.prefix == 'fr') {
+      options.oLanguage = {
+          "sProcessing":     "Traitement en cours...",
+          "sSearch":         "Rechercher&nbsp;:",
+          "sLengthMenu":     "Afficher _MENU_ &eacute;l&eacute;ments",
+          "sInfo":           "Affichage de l'&eacute;l&eacute;ment _START_ &agrave; _END_ sur _TOTAL_ &eacute;l&eacute;ments",
+          "sInfoEmpty":      "Affichage de l'&eacute;l&eacute;ment 0 &agrave; 0 sur 0 &eacute;l&eacute;ment",
+          "sInfoFiltered":   "(filtr&eacute; de _MAX_ &eacute;l&eacute;ments au total)",
+          "sInfoPostFix":    "",
+          "sLoadingRecords": "Chargement en cours...",
+          "sZeroRecords":    "Aucun &eacute;l&eacute;ment &agrave; afficher",
+          "sEmptyTable":     "Aucune donn&eacute;e disponible dans le tableau",
+          "oPaginate": {
+            "sPrevious": "<<",
+            "sNext": ">>"
+          },
+          "oAria": {
+              "sSortAscending":  ": activer pour trier la colonne par ordre croissant",
+              "sSortDescending": ": activer pour trier la colonne par ordre d&eacute;croissant"
+          }
+      }
+    }
+
+    // otherwise just load in better pagination
+    // can also be used to load in custom options
+    if(!options.oLanguage) {
       options.oLanguage = {
         "oPaginate": {
-          "sPrevious": "<<",
-          "sNext": ">>"
-        }
-      };
+            "sPrevious": "<<",
+            "sNext": ">>"
+          }
+      }
     }
 
     // Paginate to 100 per-page by default.

--- a/pulse/pulse/templates/en/domains.html
+++ b/pulse/pulse/templates/en/domains.html
@@ -16,7 +16,7 @@
 <section id="main-content">
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
-	    <table class="domain responsive https">
+	    <table id="data-table" language="en" class="domain responsive https">
 	      <caption class="sr-only">Secure HTTP(S) By Domain. Table is sortable via first row table headers. Each row contains a domain and related attributes.</caption>
 	      <thead>
 	        <tr>

--- a/pulse/pulse/templates/en/index.html
+++ b/pulse/pulse/templates/en/index.html
@@ -17,7 +17,7 @@
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    
-	    <table id="data_table" language="en" class="organization responsive https">
+	    <table id="data-table" language="en" class="organization responsive https">
 	      <caption>HTTPS by organization. Table is sortable via first row table headers. Each row contains an organization and related attributes.</caption>
 	      <thead>
 	        <tr>

--- a/pulse/pulse/templates/en/index.html
+++ b/pulse/pulse/templates/en/index.html
@@ -17,7 +17,7 @@
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    
-	    <table class="organization responsive https">
+	    <table id="data_table" language="en" class="organization responsive https">
 	      <caption>HTTPS by organization. Table is sortable via first row table headers. Each row contains an organization and related attributes.</caption>
 	      <thead>
 	        <tr>

--- a/pulse/pulse/templates/fr/domains.html
+++ b/pulse/pulse/templates/fr/domains.html
@@ -16,7 +16,7 @@
 <section id="main-content">
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
-	    <table class="domain responsive https">
+	    <table id="data-table" language="fr" class="domain responsive https">
 	      <caption class="sr-only">Secure HTTP(S) By Domain. Table is sortable via first row table headers. Each row contains a domain and related attributes.</caption>
 	      <thead>
 	        <tr>

--- a/pulse/pulse/templates/fr/domains.html
+++ b/pulse/pulse/templates/fr/domains.html
@@ -17,16 +17,16 @@
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    <table id="data-table" language="fr" class="domain responsive https">
-	      <caption class="sr-only">Secure HTTP(S) By Domain. Table is sortable via first row table headers. Each row contains a domain and related attributes.</caption>
+	      <caption class="sr-only">HTTP(S) sécurisé par domaine. Le tableau peut être trié par en-tête de tableau de première ligne. Chaque ligne contient un domaine et les attributs connexes.</caption>
 	      <thead>
 	        <tr>
 	          <th class="never"></th>
-	          <th class="all">Domain</th>
-	          <th class="never">Agency</th>
-	          <th class="min-tablet">Enforces HTTPS</th>
+	          <th class="all">Domaine</th>
+	          <th class="never">Organisation</th>
+	          <th class="min-tablet">Applique le protocole HTTPS</th>
 	          <th class="min-tablet">HSTS</th>
-	          <th class="min-tablet-l">Free of RC4/3DES and SSLv2/SSLv3</th>
-	          <th class="min-tablet-l">Preloaded</th>
+	          <th class="min-tablet-l">RC4/3DES et SSLv2/SSLv3 non utilisés</th>
+	          <th class="min-tablet-l">Domaines préchargés</th>
 	          <th class="none" scope="col"></th>
 	        </tr>
 	      </thead>

--- a/pulse/pulse/templates/fr/index.html
+++ b/pulse/pulse/templates/fr/index.html
@@ -17,7 +17,7 @@
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    
-	    <table id="data_table" language="fr" class="organization responsive https">
+	    <table id="data-table" language="fr" class="organization responsive https">
 	      <caption>HTTPS by agency. Table is sortable via first row table headers. Each row contains an agency and related attributes.</caption>
 	      <thead>
 	        <tr>

--- a/pulse/pulse/templates/fr/index.html
+++ b/pulse/pulse/templates/fr/index.html
@@ -17,16 +17,16 @@
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    
-	    <table class="agency responsive https">
+	    <table id="data_table" language="fr" class="organization responsive https">
 	      <caption>HTTPS by agency. Table is sortable via first row table headers. Each row contains an agency and related attributes.</caption>
 	      <thead>
 	        <tr>
 	          <th class="never"></th>
-	          <th class="all" scope="col">Organization</th>
-	          <th class="min-tablet" scope="col">Enforces HTTPS</th>
+	          <th class="all" scope="col">Organisation</th>
+	          <th class="min-tablet" scope="col">Applique le protocole HTTPS</th>
 	          <th class="desktop" scope="col">HSTS</th>
-	          <th class="desktop" scope="col">Free of RC4/3DES and SSLv2/SSLv3</th>
-	          <th class="desktop" scope="col">Preloaded Domains</th>
+	          <th class="desktop" scope="col">RC4/3DES et SSLv2/SSLv3 non utilisés</th>
+	          <th class="desktop" scope="col">Domaines préchargés</th>
 	        </tr>
 	      </thead>
     	</table>
@@ -35,5 +35,5 @@
 
 </section>
 
-<script src="/static/js/https/agencies.js?{{ now() | date("%Y%m%j%H%M%S") }}"></script>
+<script src="/static/js/https/organizations.js?{{ now() | date("%Y%m%j%H%M%S") }}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR adds support for French tables, yay!

Data tables will now accept a language prefix, and based on the language prefix load in translations for basic table functions and pass in translations for the table text. All table functions should work, including the filtering from the french organization table to the french domain table. 