### PR TITLE
Change text in tables

### DIFF
--- a/pulse/pulse/static/js/https/domains.js
+++ b/pulse/pulse/static/js/https/domains.js
@@ -133,6 +133,11 @@ $(function () {
     error: {
       en: "Error loading data for ",
       fr: "Erreur dans le téléchargement des données de "
+    },
+
+    subdomains: {
+      en: " subdomains",
+      fr: " sous-domaines"
     }
 
   };
@@ -280,7 +285,7 @@ $(function () {
     if (loneDomain(row))
       return (show ? "<img src=\"/static/images/arrow.png\" class=\"rotated pb-1 mr-1 h-2\">" + text.show[language] : "<img src=\"/static/images/arrow.png\" class=\"mr-2 h-2\">" + text.hide[language]) + " " + text.details[language];
     else
-      return (show ? "<img src=\"/static/images/arrow.png\" class=\"rotated pb-1 mr-1 h-2\">" + text.show[language] : "<img src=\"/static/images/arrow.png\" class=\"mr-2 h-2\">" + text.hide[language]) + " " + row.totals.https.eligible + " services";
+      return (show ? "<img src=\"/static/images/arrow.png\" class=\"rotated pb-1 mr-1 h-2\">" + text.show[language] : "<img src=\"/static/images/arrow.png\" class=\"mr-2 h-2\">" + text.hide[language]) + " " + row.totals.https.eligible + text.subdomains[language];
   };
 
   var initExpansions = function() {

--- a/pulse/pulse/static/js/https/organizations.js
+++ b/pulse/pulse/static/js/https/organizations.js
@@ -46,24 +46,33 @@ $(document).ready(function () {
   //get table language
   var language = $( "#data-table" ).attr("language");
 
+  var text = {
+    show: {
+      en: "Show",
+      fr: "Montrer"
+    },
+
+    domains: {
+      en: "domains",
+      fr: "domaines"
+    },
+
+    domain_singular: {
+      en: "domain",
+      fr: "domaine"
+    }
+  };
+
   var eligibleHttps = function(data, type, row) {
     var services = row.https.eligible;
     var domains = row.total_domains;
 
-    if(language == 'en') {
+    if(language == 'en')
       var name = row.name_en;
-      var link_text = "Show";
-    }
-    else {
+    else
       var name = row.name_fr;
-      var link_text = "Montrer";
-    }
 
-    var services_text = "service";
     if (type == "sort") return name;
-
-    if(services > 1) 
-      services_text = "services"
 
     var link = function(text) {
       return "" +
@@ -73,9 +82,10 @@ $(document).ready(function () {
         "</a>";
     }
 
-
-    return "<div class=\"mb-2\">" + name + "</div>" + link(link_text + " " + services + " " + services_text);
-
+    if(services > 1)
+      return "<div class=\"mb-2\">" + name + "</div>" + link(text.show[language] + " " + services + " " + text.domains[language]);
+    else
+      return "<div class=\"mb-2\">" + name + "</div>" + link(text.show[language] + " " + services + " " + text.domain_singular[language]);
   };
 
 


### PR DESCRIPTION
This PR updates the text in the organization & domain tables to read domains or subdomains instead of services. This also includes a tiny bit of refactoring of the organization table js to make it a little bit prettier. 