### PR TITLE
change default db name to match default name in flask app

### DIFF
--- a/tracker/data/cli.py
+++ b/tracker/data/cli.py
@@ -54,7 +54,7 @@ def transform_args(args: typing.List[str]) -> typing.Dict[str, typing.Union[str,
 
 
 @click.group()
-@click.option("--connection", type=str, default="mongodb://localhost:21017/tracker", envvar="TRACKER_MONGO_URI")
+@click.option("--connection", type=str, default="mongodb://localhost:21017/track", envvar="TRACKER_MONGO_URI")
 @click.pass_context
 def main(ctx: click.core.Context, connection: str) -> None:
     ctx.obj = {

--- a/tracker/data/models.py
+++ b/tracker/data/models.py
@@ -43,7 +43,7 @@ class _Collection():
         try:
             self._db = client.get_database().name
         except pymongo.errors.ConfigurationError:
-            self._db = 'tracker'
+            self._db = 'track'
 
     def create_all(self, documents: typing.Iterable[typing.Dict]) -> None:
         _insert_all(self._client, self._name, documents, self._db)

--- a/tracker/tests/test_models.py
+++ b/tracker/tests/test_models.py
@@ -7,7 +7,7 @@ from data import models
 
 
 def connection_string() -> str:
-    database = f'tracker_{random.randint(0, 1000)}'
+    database = f'track_{random.randint(0, 1000)}'
     connection = f'mongodb://localhost:27017/{database}'
 
     return connection
@@ -23,7 +23,7 @@ def connection(request: _pytest.fixtures.SubRequest) -> typing.Iterator[models.C
         try:
             client.drop_database(client.get_database())
         except pymongo.errors.ConfigurationError:
-            client.drop_database('tracker')
+            client.drop_database('track')
 
 class TestDomains:
 


### PR DESCRIPTION
Default DB name in the `tracker` portion did not match the DB name in the `track_digital` portion, this PR corrects that.