### PR TITLE
add missing default db name

### DIFF
--- a/track_digital/track/config.py
+++ b/track_digital/track/config.py
@@ -4,7 +4,7 @@ import random
 class Config():
     DEBUG = False
     TESTING = False
-    MONGO_URI = 'mongodb://localhost:27017/tracker'
+    MONGO_URI = 'mongodb://localhost:27017/track'
 
 
 class ProductionConfig(Config):
@@ -17,4 +17,4 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(Config):
     TESTING = True
-    MONGO_URI = f'mongodb://localhost:27017/tracker_{random.randint(0, 1000)}'
+    MONGO_URI = f'mongodb://localhost:27017/track_{random.randint(0, 1000)}'


### PR DESCRIPTION
This PR changes the default DB name to match the default of other places. This was missed in the rebranding PR.