### PR TITLE
remove unused cruft

### DIFF
--- a/tracker/Makefile
+++ b/tracker/Makefile
@@ -3,7 +3,7 @@
 # Run a fresh scan, update the database, and upload data to S3.
 # Enable Lambda mode, using Lambda AWS profile set up in production.
 update_production:
-	tracker run --scan here --upload --lambda --lambda-profile lambda
+	tracker run --scan here --lambda --lambda-profile lambda
 
 # Development data update process:
 #

--- a/tracker/data/cli.py
+++ b/tracker/data/cli.py
@@ -67,9 +67,8 @@ def main(ctx: click.core.Context, connection: str) -> None:
     help="Coposition of `update`, `process`, and `upload` commands",
 )
 @click.option("--date", type=DATE)
-@click.option("--scan", type=click.Choice(["skip", "download", "here"]), default="skip")
+@click.option("--scan", type=click.Choice(["skip", "here"]), default="skip")
 @click.option("--gather", type=click.Choice(["skip", "here"]), default="here")
-@click.option("--upload-results", is_flag=True, default=False)
 @click.argument("scan_args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_context
 def run(
@@ -77,15 +76,12 @@ def run(
         date: typing.Optional[str],
         scan: str,
         gather: str,
-        upload_results: bool,
         scan_args: typing.List[str],
     ) -> None:
 
     update.callback(scan, gather, scan_args)
     the_date = get_date(None, "date", date)
     process.callback(the_date)
-    if upload_results:
-        upload.callback(the_date)
 
 
 @main.command()
@@ -107,26 +103,6 @@ def update(scan: str, gather: str, scan_args: typing.List[str]) -> None:
     LOGGER.info("Starting update")
     data_update.update(scan, gather, transform_args(scan_args))
     LOGGER.info("Finished update")
-
-
-@main.command(help="Download scan results from s3")
-def download() -> None:
-    LOGGER.info("Downloading production data")
-    data_update.download_s3()
-    LOGGER.info("Finished downloading production data")
-
-
-@main.command(help="Upload scan results to s3")
-@click.option("--date", type=DATE, callback=get_date)
-def upload(date: str) -> None:
-    # Sanity check to make sure we have what we need.
-    if not os.path.exists(os.path.join(PARENTS_RESULTS, "meta.json")):
-        LOGGER.info("No scan metadata downloaded, aborting.")
-        return
-
-    LOGGER.info(f"[{date}] Syncing scan data and database to S3.")
-    data_update.upload_s3(date)
-    LOGGER.info(f"[{date}] Scan data and database now in S3.")
 
 
 @main.command(help="Process scan data")

--- a/tracker/data/data_meta.yml
+++ b/tracker/data/data_meta.yml
@@ -8,5 +8,3 @@ data:
   # Some other websites
   other_subdomains_url: "./csv/subdomains.csv"
 
-bucket: cg-4adefb86-dadb-4ecf-be3e-f1c7b4f6d084
-aws_region: us-gov-west-1

--- a/tracker/data/env.py
+++ b/tracker/data/env.py
@@ -25,10 +25,6 @@ SUBDOMAIN_DATA = os.path.join(DATA_DIR, "./output/subdomains")
 SUBDOMAIN_DATA_GATHERED = os.path.join(DATA_DIR, "./output/subdomains/gather")
 SUBDOMAIN_DATA_SCANNED = os.path.join(DATA_DIR, "./output/subdomains/scan")
 
-DB_DATA = os.path.join(DATA_DIR, "./db.json")
-BUCKET_NAME = META["bucket"]
-AWS_REGION = META["aws_region"]
-
 ### Parent domain scanning information
 # Run these scanners over *all* (which is a lot) discovered subdomains.
 SCANNERS = ["pshtt", "sslyze"]
@@ -45,26 +41,3 @@ GATHERER_OPTIONS = [
 
 # Used if --lambda is enabled during the scan.
 LAMBDA_WORKERS = 900
-
-# Quick and dirty CLI options parser.
-def options():
-    options = {}
-    for arg in sys.argv[1:]:
-        if arg.startswith("--"):
-
-            if "=" in arg:
-                key, value = arg.split("=")
-            else:
-                key, value = arg, "true"
-
-            key = key.split("--")[1]
-            key = key.lower()
-            value = value.lower()
-
-            if value == "true":
-                value = True
-            elif value == "false":
-                value = False
-            options[key] = value
-
-    return options

--- a/tracker/tests/test_cli.py
+++ b/tracker/tests/test_cli.py
@@ -22,8 +22,6 @@ def test_run_all_args(
     ) -> None:
     monkeypatch.setattr(update, 'update', noop)
     monkeypatch.setattr(processing, 'run', noop)
-    monkeypatch.setattr(update, 'download_s3', noop)
-    monkeypatch.setattr(update, 'upload_s3', noop)
 
     date, exit_code = date_result
 
@@ -33,7 +31,6 @@ def test_run_all_args(
         '--date', date,
         '--scan', 'here',
         '--gather', 'here',
-        '--upload'
     ])
     assert result.exit_code == exit_code
 
@@ -63,30 +60,5 @@ def test_process(
     result = runner.invoke(cli.main, args=[
         'process',
         '--date', date,
-    ])
-    assert result.exit_code == exit_code
-
-
-def test_download(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:
-    monkeypatch.setattr(update, 'download_s3', noop)
-
-    runner = CliRunner()
-    result = runner.invoke(cli.main, args=[
-        'download',
-    ])
-    assert result.exit_code == 0
-
-
-def test_upload(
-        date_result,
-        monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:
-
-    date, exit_code = date_result
-    monkeypatch.setattr(update, 'upload_s3', noop)
-
-    runner = CliRunner()
-    result = runner.invoke(cli.main, args=[
-        'upload',
-        '--date', date
     ])
     assert result.exit_code == exit_code


### PR DESCRIPTION
This PR removes the unused functionality of uploading and downloading scan results to an S3 bucket. It's completely unused, and historical records of scan results has been brought up and explicitly decided as a "for now no" feature.

As such here is some house keeping.