### PR TITLE
Check for old TLS versions

### DIFF
--- a/track_digital/tests/test_models.py
+++ b/track_digital/tests/test_models.py
@@ -97,6 +97,8 @@ class TestDomain():
                 'rc4': False,
                 'sslv2': False,
                 'sslv3': False,
+                'tlsv10': False,
+                'tlsv11': False,
                 'uses': 2
             },
             'is_parent': True,
@@ -110,8 +112,10 @@ class TestDomain():
                     'eligible': 1,
                     'rc4': 0,
                     'sslv2': 0,
-                    'sslv3': 0},
-                'https': {
+                    'sslv3': 0,
+                    'tlsv10': 0,
+                    'tlsv11': 0,
+                }, 'https': {
                     'compliant': 0,
                     'eligible': 1,
                     'enforces': 0,
@@ -198,6 +202,8 @@ class TestDomain():
                 'RC4',
                 'SSLv2',
                 'SSLv3',
+                'TLSv1.0',
+                'TLSv1.1',
                 'Preloaded'
             ]
             assert next(reader) == {
@@ -214,6 +220,8 @@ class TestDomain():
                 'RC4': 'No',
                 'SSLv2': 'No',
                 'SSLv3': 'No',
+                'TLSv1.0': 'No',
+                'TLSv1.1': 'No',
                 'Preloaded': 'No'
             }
 
@@ -242,7 +250,9 @@ class TestOrganizations():
                 "rc4" : 0,
                 "3des" : 1,
                 "sslv2" : 0,
-                "sslv3" : 0
+                "sslv3" : 0,
+                "tlsv10": 0,
+                "tlsv11": 0
             },
             "preloading" : {
                 "eligible" : 3,

--- a/track_digital/track/data.py
+++ b/track_digital/track/data.py
@@ -64,6 +64,8 @@ CSV_FIELDS = {
         "rc4",
         "sslv2",
         "sslv3",
+        "tlsv1.0",
+        "tlsv1.1",
         "preloaded",
     ],
 }

--- a/track_digital/track/data.py
+++ b/track_digital/track/data.py
@@ -23,6 +23,8 @@ LABELS = {
         "rc4": "RC4",
         "sslv2": "SSLv2",
         "sslv3": "SSLv3",
+        "tlsv10": "TLSv1.0",
+        "tlsv11": "TLSv1.1",
     },
 }
 
@@ -64,8 +66,8 @@ CSV_FIELDS = {
         "rc4",
         "sslv2",
         "sslv3",
-        "tlsv1.0",
-        "tlsv1.1",
+        "tlsv10",
+        "tlsv11",
         "preloaded",
     ],
 }

--- a/tracker/data/processing.py
+++ b/tracker/data/processing.py
@@ -545,6 +545,8 @@ def https_behavior_for(name, pshtt, sslyze, parent_preloaded=None):
     sslv3 = None
     any_rc4 = None
     any_3des = None
+    tlsv10 = None
+    tlsv11 = None
 
     # values: unknown or N/A (-1), No (0), Yes (1)
     bod_crypto = None
@@ -573,11 +575,19 @@ def https_behavior_for(name, pshtt, sslyze, parent_preloaded=None):
         else:
             bod_crypto = 1
 
+       ###
+       # ITPIN cares about usage of TLS 1.0 and TLS 1.1
+       tlsv10 = boolean_for(sslyze["TLSv1.0"])
+       tlsv11 = boolean_for(sslyze["TLSv1.1"])
+
     report["bod_crypto"] = bod_crypto
     report["rc4"] = any_rc4
     report["3des"] = any_3des
     report["sslv2"] = sslv2
     report["sslv3"] = sslv3
+    report["tlsv1.0"] = tlsv10
+    report["tlsv1.1"] = tlsv11
+
 
     # Final calculation: is the service compliant with all of M-15-13
     # (HTTPS+HSTS) and BOD 18-01 (that + RC4/3DES/SSLv2/SSLv3)?

--- a/tracker/data/processing.py
+++ b/tracker/data/processing.py
@@ -575,10 +575,10 @@ def https_behavior_for(name, pshtt, sslyze, parent_preloaded=None):
         else:
             bod_crypto = 1
 
-       ###
-       # ITPIN cares about usage of TLS 1.0 and TLS 1.1
-       tlsv10 = boolean_for(sslyze["TLSv1.0"])
-       tlsv11 = boolean_for(sslyze["TLSv1.1"])
+        ###
+        # ITPIN cares about usage of TLS 1.0 and TLS 1.1
+        tlsv10 = boolean_for(sslyze["TLSv1.0"])
+        tlsv11 = boolean_for(sslyze["TLSv1.1"])
 
     report["bod_crypto"] = bod_crypto
     report["rc4"] = any_rc4

--- a/tracker/data/processing.py
+++ b/tracker/data/processing.py
@@ -585,8 +585,8 @@ def https_behavior_for(name, pshtt, sslyze, parent_preloaded=None):
     report["3des"] = any_3des
     report["sslv2"] = sslv2
     report["sslv3"] = sslv3
-    report["tlsv1.0"] = tlsv10
-    report["tlsv1.1"] = tlsv11
+    report["tlsv10"] = tlsv10
+    report["tlsv11"] = tlsv11
 
 
     # Final calculation: is the service compliant with all of M-15-13
@@ -660,6 +660,8 @@ def total_crypto_report(eligible):
         "3des": 0,
         "sslv2": 0,
         "sslv3": 0,
+        "tlsv10": 0,
+        "tlsv11": 0,
     }
 
     for report in eligible:
@@ -679,6 +681,10 @@ def total_crypto_report(eligible):
             total_report["sslv2"] += 1
         if report["sslv3"]:
             total_report["sslv3"] += 1
+        if report["tlsv10"]:
+            total_report["tlsv10"] += 1
+        if report["tlsv11"]:
+            total_report["tlsv11"] += 1
 
     return total_report
 


### PR DESCRIPTION
This PR extracts the usage of TLS v1.0 and 1.1 and stores it along with the other crypto info in the processing stage.

Access to the information should be the same as access to the other information, additional fields have been just been added to the csv export.