### PR TITLE
Sticky footer fix for IE

### DIFF
--- a/track_digital/track/templates/en/domains.html
+++ b/track_digital/track/templates/en/domains.html
@@ -4,17 +4,18 @@
 {% block pageid %}domains{% endblock %}
 
 {% block content %}
-<header class="bg-grey-lighter py-6">
 
-	{% include 'includes/https/en/header.html' %}
+<section id="main-content" class="flex-1">
 
-	<div class="text-center mt-8 font-bold">
-		<p class="uppercase"><a href="/en/organizations/" class="mr-8 text-blue hover:text-blue-darker">by organization</a> by domain</a></p>
-	</div>
+	<header class="bg-grey-lighter py-6">
 
-</header>
+		{% include 'includes/https/en/header.html' %}
 
-<section id="main-content">
+		<div class="text-center mt-8 font-bold">
+			<p class="uppercase"><a href="/en/organizations/" class="mr-8 text-blue hover:text-blue-darker">by organization</a> by domain</a></p>
+		</div>
+
+	</header>
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    <table id="data-table" language="en" class="domain responsive https">

--- a/track_digital/track/templates/en/feedback.html
+++ b/track_digital/track/templates/en/feedback.html
@@ -4,7 +4,7 @@
 {% block pageid %}feedback{% endblock %}
 
 {% block content %}
-<section id="main-content">
+<section id="main-content" class="flex-1">
 	<div class="container mx-auto items-center sm:w-4/5 xl:w-3/5 mt-6">
 		<h1>Feedback</h1>
 		<p>For inquiries, questions, or comments about this dashboard or implementing HTTPS, please send an email to <a href="mailto:zzTBSCybers@tbs-sct.gc.ca" class="text-blue hover:text-blue-darker font-bold">TBS Cyber Security</a> or join the <a href="https://gcconnex.gc.ca/groups/profile/35218846/gc-https-everywhere-2018-https-partout-dans-le-gc-2018?language=en" class="text-blue hover:text-blue-darker font-bold">HTTPS Everywhere group on GCconnex</a>.</p>

--- a/track_digital/track/templates/en/guidance.html
+++ b/track_digital/track/templates/en/guidance.html
@@ -4,7 +4,7 @@
 {% block pageid %}guidance{% endblock %}
 
 {% block content %}
-<section id="main-content">
+<section id="main-content" class="flex-1">
 	<div class="container mx-auto items-center sm:w-4/5 xl:w-3/5 mt-6 mb-6">
 		<h1>Guidance</h1>
 		<ul class="leading-normal mb-4">

--- a/track_digital/track/templates/en/index.html
+++ b/track_digital/track/templates/en/index.html
@@ -4,17 +4,18 @@
 {% block pageid %}organizations{% endblock %}
 
 {% block content %}
-<header class="bg-grey-lighter py-6">
 
-	{% include 'includes/https/en/header.html' %}
+<section id="main-content" class="flex-1">
 
-	<div class="text-center mt-8 font-bold">
-		<p class="uppercase">by organization <a href="/en/domains/" class="ml-8 text-blue hover:text-blue-darker">by domain</a></p>
-	</div>
+	<header class="bg-grey-lighter py-6">
 
-</header>
+		{% include 'includes/https/en/header.html' %}
 
-<section id="main-content">
+		<div class="text-center mt-8 font-bold">
+			<p class="uppercase">by organization <a href="/en/domains/" class="ml-8 text-blue hover:text-blue-darker">by domain</a></p>
+		</div>
+
+	</header>
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    

--- a/track_digital/track/templates/en/layout-en.html
+++ b/track_digital/track/templates/en/layout-en.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="flex">
 
 <head>
 	
@@ -9,7 +9,7 @@
 	
 </head>
 
-<body class="flex flex-col h-screen ">
+<body class="flex flex-1 flex-col min-h-screen">
 
 	<header role="banner">
 
@@ -41,7 +41,7 @@
 
 	</header>
 
-	<main class="flex-1">
+	<main class="flex-grow flex-shrink flex-auto">
 
 		{% block content %}{% endblock %}
 

--- a/track_digital/track/templates/en/layout-en.html
+++ b/track_digital/track/templates/en/layout-en.html
@@ -41,7 +41,7 @@
 
 	</header>
 
-	<main class="flex-grow flex-shrink flex-auto">
+	<main class="flex flex-auto">
 
 		{% block content %}{% endblock %}
 

--- a/track_digital/track/templates/fr/domains.html
+++ b/track_digital/track/templates/fr/domains.html
@@ -4,17 +4,18 @@
 {% block pageid %}domains{% endblock %}
 
 {% block content %}
-<header class="bg-grey-lighter py-6">
 
-	{% include 'includes/https/fr/header.html' %}
+<section id="main-content" class="flex-1">
 
-	<div class="text-center mt-8 font-bold">
-		<p class="uppercase"><a href="/fr/organizations/" class="mr-8 text-blue hover:text-blue-darker">par organisation</a> par domaine</a></p>
-	</div>
+	<header class="bg-grey-lighter py-6">
 
-</header>
+		{% include 'includes/https/fr/header.html' %}
 
-<section id="main-content">
+		<div class="text-center mt-8 font-bold">
+			<p class="uppercase"><a href="/fr/organizations/" class="mr-8 text-blue hover:text-blue-darker">par organisation</a> par domaine</a></p>
+		</div>
+
+	</header>
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    <table id="data-table" language="fr" class="domain responsive https">

--- a/track_digital/track/templates/fr/feedback.html
+++ b/track_digital/track/templates/fr/feedback.html
@@ -4,7 +4,7 @@
 {% block pageid %}feedback{% endblock %}
 
 {% block content %}
-<section id="main-content">
+<section id="main-content" class="flex-1">
 	<div class="container mx-auto items-center sm:w-4/5 xl:w-3/5 mt-6">
 		<h1>Rétroaction</h1>
 		<p>Veuillez transmettre vos questions ou commentaires au sujet de ce tableau de bord ou de la mise en œuvre de HTTPS par courriel à la <a href="mailto:zzTBSCybers@tbs-sct.gc.ca" class="text-blue hover:text-blue-darker font-bold">Cybersécurité du SCT</a> ou joindre le groupe <a href="https://gcconnex.gc.ca/groups/profile/35218846/gc-https-everywhere-2018-https-partout-dans-le-gc-2018?language=en" class="text-blue hover:text-blue-darker font-bold">« HTTPS Everywhere » sur GCconnex</a>.</p>

--- a/track_digital/track/templates/fr/guidance.html
+++ b/track_digital/track/templates/fr/guidance.html
@@ -4,7 +4,7 @@
 {% block pageid %}guidance{% endblock %}
 
 {% block content %}
-<section id="main-content">
+<section id="main-content" class="flex-1">
 	<div class="container mx-auto items-center sm:w-4/5 xl:w-3/5 mt-6 mb-6">
 		<h1>Directives</h1>
 		<ul class="leading-normal mb-4">

--- a/track_digital/track/templates/fr/index.html
+++ b/track_digital/track/templates/fr/index.html
@@ -4,17 +4,18 @@
 {% block pageid %}organizations{% endblock %}
 
 {% block content %}
-<header class="bg-grey-lighter py-6">
 
-	{% include 'includes/https/fr/header.html' %}
+<section id="main-content" class="flex-1">
 
-	<div class="text-center mt-8 font-bold">
-		<p class="uppercase">par organization <a href="/fr/domains/" class="ml-8 text-blue hover:text-blue-darker">par domaine</a></p>
-	</div>
+	<header class="bg-grey-lighter py-6">
 
-</header>
+		{% include 'includes/https/fr/header.html' %}
 
-<section id="main-content">
+		<div class="text-center mt-8 font-bold">
+			<p class="uppercase">par organization <a href="/fr/domains/" class="ml-8 text-blue hover:text-blue-darker">par domaine</a></p>
+		</div>
+
+	</header>
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    

--- a/track_digital/track/templates/fr/layout-fr.html
+++ b/track_digital/track/templates/fr/layout-fr.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="fr" class="flex">
 
 <head>
 	
@@ -9,7 +9,7 @@
 	
 </head>
 
-<body class="flex flex-col h-screen ">
+<body class="flex flex-1 flex-col min-h-screen">
 
 	<header role="banner">
 
@@ -41,7 +41,7 @@
 
 	</header>
 
-	<main class="flex-1">
+	<main class="flex flex-auto">
 
 		{% block content %}{% endblock %}
 


### PR DESCRIPTION
This PR modifies the CSS so the sticky footer works properly on IE, with no visual differences on other browsers. Tested using Browserstack on IE 10 & 11. 