### PR TITLE
French dynamic date 

### DIFF
--- a/track_digital/setup.py
+++ b/track_digital/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         'flask-compress==1.4.0',
         'click==6.7',
         'gevent==1.2.2',
+        'Babel==2.6.0',
     ],
     extras_require={
         'development': [

--- a/track_digital/track/helpers.py
+++ b/track_digital/track/helpers.py
@@ -4,6 +4,7 @@ import yaml
 import datetime
 from track import models
 from track.data import FIELD_MAPPING
+from babel.dates import format_date
 
 # For use in templates.
 def register(app):
@@ -31,6 +32,10 @@ def register(app):
     @app.template_filter("date")
     def datetimeformat(value, format="%H:%M / %d-%m-%Y"):
         return value.strftime(format)
+
+    @app.template_filter("display_date")
+    def displaydateformat(value, lang):
+        return format_date(value, format='long', locale=lang)
 
     @app.template_filter("field_map")
     def field_map(value, category=None, field=None):

--- a/track_digital/track/templates/includes/https/en/header.html
+++ b/track_digital/track/templates/includes/https/en/header.html
@@ -1,6 +1,6 @@
 <div class="container mx-auto items-center sm:w-4/5 xl:w-3/5">
 	<h1 class="text-4xl sm:text-5xl">HTTPS</h1>
-	<h2 class="mb-4 sm:mb-6 text-xl sm:text-2xl">Last updated {{ scan_date | date("%B %d, %Y") }}</h2>
+	<h2 class="mb-4 sm:mb-6 text-xl sm:text-2xl">Last updated {{ scan_date | display_date("en") }}</h2>
 	<p class="text-lg mb-6">Canadians rely on the Government of Canada to provide secure digital services and expect government websites to be secure and private. The Government of Canada is committed to ensuring that all publicly accessible government websites and services are configured to provide service through a secure connection, as outlined in the <a href="https://www.canada.ca/en/treasury-board-secretariat/services/information-technology/strategic-plan-2017-2021.html#toc8-3-2" class="text-blue hover:text-blue-darker font-bold">IM/IT Strategic Plan 2017-21</a>, and the upcoming Security Policy Implementation Notice (SPIN).</p>
 	<p class="text-lg mb-8">This dashboard measures how well federal government domains are meeting best practices on the web. Implementing the HTTPS protocol (<span class="font-mono">https://</span>), along with approved encryption algorithms, offers a level of security and privacy that users should expect from Government of Canada web services.</p>
 

--- a/track_digital/track/templates/includes/https/fr/header.html
+++ b/track_digital/track/templates/includes/https/fr/header.html
@@ -1,6 +1,6 @@
 <div class="container mx-auto items-center sm:w-4/5 xl:w-3/5">
 	<h1 class="text-4xl sm:text-5xl">HTTPS</h1>
-	<h2 class="mb-4 sm:mb-6 text-xl sm:text-2xl">Dernière mise à jour 16 mai 2018</h2>
+	<h2 class="mb-4 sm:mb-6 text-xl sm:text-2xl">Dernière mise à jour {{ scan_date | display_date("fr") }}</h2>
 	<p class="text-lg mb-6">Les Canadiens comptent sur le gouvernement du Canada pour fournir des services numériques sécurisés et s’attendent à ce que les sites Web du gouvernement soient protégés et privés. Le gouvernement du Canada s’est engagé à faire en sorte que tous les sites Web et services gouvernementaux ouverts au public soient configurés de façon à être accessibles par une connexion sécurisée, comme l’indique le Plan stratégique de <a href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/technologie-information/plan-strategique-2017-2021.html#toc8-3-2" class="text-blue hover:text-blue-darker font-bold">GI/TI 2017-21</a> et le prochain Avis de mise en œuvre de la Politique sur la sécurité (AMOPS).</p>
 	<p class="text-lg mb-8">Le présent tableau de bord évalue la mesure dans laquelle les domaines du gouvernement fédéral respectent les pratiques exemplaires sur le Web. La mise en œuvre du protocole HTTPS (<span class="font-mono">https://</span>), et l’adoption d’algorithmes de chiffrement approuvés assurent un niveau de sécurité et de protection des renseignements personnels auquel s’attendent les utilisateurs des services Web du gouvernement du Canada.</p>
 


### PR DESCRIPTION
This PR adds a custom filter to display the date correctly in English & French using Babel's format_date  function.

"Why a new date filter when one already exists?" David will ask. The current date function is used for more than just the date displayed to the user, and the extra uses don't meld well with format_date. So it was easier to create a function specifically for display purposes that accepts the language you want the date displayed in. 