### PR TITLE
Fix table attribute generation

### DIFF
--- a/track_digital/track/static/js/dataTables.downloads.js
+++ b/track_digital/track/static/js/dataTables.downloads.js
@@ -20,7 +20,7 @@ $.fn.dataTable.Download = function ( inst ) {
   var container = $('<div></div>').addClass( 'dataTables_csv' );
   var drawnOnce = false;
 
-  var language = $( "#data-table" ).attr("language");
+  var language = $( "table" ).attr("language");
 
   if(language == 'en')
     var text = "Download as CSV"

--- a/track_digital/track/static/js/https/domains.js
+++ b/track_digital/track/static/js/https/domains.js
@@ -64,7 +64,7 @@ $(function () {
   });
 
   //get table language
-  var language = $( "#data-table" ).attr("language");
+  var language = $( "table" ).attr("language");
 
   /**
   * I don't like this at all, but to keep the presentation synced

--- a/track_digital/track/static/js/https/organizations.js
+++ b/track_digital/track/static/js/https/organizations.js
@@ -44,7 +44,7 @@ $(document).ready(function () {
   });
 
   //get table language
-  var language = $( "#data-table" ).attr("language");
+  var language = $( "table" ).attr("language");
 
   var text = {
     show: {

--- a/track_digital/track/static/js/tables.js
+++ b/track_digital/track/static/js/tables.js
@@ -163,6 +163,6 @@ $(function() {
     $('.dataTables_filter label').attr('for', 'datatables-search');
     $('.dataTables_filter label').attr('class', 'block');
     $('#DataTables_Table_0_filter').find('input[type="search"]').attr('id', 'datatables-search');
-    $('#DataTables_Table_0_filter').find('input[type="search"]').attr('class', 'inline-block border border-solid border-grey-darker');
+    //$('#DataTables_Table_0_filter').find('input[type="search"]').attr('class', 'inline-block border border-solid border-grey-darker');
   });
 });

--- a/track_digital/track/templates/en/domains.html
+++ b/track_digital/track/templates/en/domains.html
@@ -18,7 +18,7 @@
 	</header>
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
-	    <table id="data-table" language="en" class="domain responsive https">
+	    <table language="en" class="domain responsive https">
 	      <caption class="sr-only">Secure HTTP(S) By Domain. Table is sortable via first row table headers. Each row contains a domain and related attributes.</caption>
 	      <thead>
 	        <tr>

--- a/track_digital/track/templates/fr/index.html
+++ b/track_digital/track/templates/fr/index.html
@@ -19,7 +19,7 @@
 
 	<div id="tab-panel" class="container mx-auto" role="tabpanel" aria-hidden="false">
 	    
-	    <table id="data-table" language="fr" class="organization responsive https">
+	    <table language="fr" class="organization responsive https">
 	      <caption>HTTPS par organisme. Le tableau peut être trié par en-tête de tableau de première ligne. Chaque ligne contient le nom d’une organisation et les attributs connexes.</caption>
 	      <thead>
 	        <tr>


### PR DESCRIPTION
Minor fix - by adding an id for table selection, I accidentally affected how the table ids are generated by datatables. This wouldn't be a big deal (the ids play a big role if you have more than one table on the page), except that some of the accessibility coding relies on having the ids generated a certain way, so I decided to fix it.

This PR removes the table id and changes the selection to just the table, which will work consistently since we only ever have one table per page.