### PR TITLE
remove f-strings so we can be 3.5+ instead of 3.6+

### DIFF
--- a/track_digital/track/config.py
+++ b/track_digital/track/config.py
@@ -17,4 +17,4 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(Config):
     TESTING = True
-    MONGO_URI = f'mongodb://localhost:27017/track_{random.randint(0, 1000)}'
+    MONGO_URI = 'mongodb://localhost:27017/track_{rand}'.format(rand=random.randint(0, 1000))

--- a/track_digital/track/data.py
+++ b/track_digital/track/data.py
@@ -1,4 +1,4 @@
-
+import typing
 # Mapping report/domain/organization field names to display names.
 LABELS = {
     # used in export CSVs
@@ -30,7 +30,7 @@ LABELS = {
 }
 
 
-FIELD_MAPPING = {
+FIELD_MAPPING: typing.Dict[str, typing.Dict] = {
     "common": {},
     "https": {
         "uses": {

--- a/track_digital/track/views.py
+++ b/track_digital/track/views.py
@@ -30,7 +30,7 @@ def register(app):
 
     def generate_path(prefix, page_id):
         if(prefix == 'en' or prefix == 'fr'):
-            return os.path.join(prefix, f'{page_id}.html')
+            return os.path.join(prefix, '{}.html'.format(page_id))
         else:
             abort(404)
 

--- a/tracker/data/cli.py
+++ b/tracker/data/cli.py
@@ -24,7 +24,7 @@ class DateType(click.ParamType):
             datetime.datetime.strptime(value, "%Y-%m-%d")
             return value
         except ValueError:
-            self.fail(f"{value} is not a valid date")
+            self.fail("{value} is not a valid date".format(value=value))
 DATE = DateType()
 
 
@@ -119,9 +119,9 @@ def process(ctx: click.core.Context, date: str) -> None:
         LOGGER.info("No scan metadata downloaded, aborting.")
         return
 
-    LOGGER.info(f"[{date}] Loading data into track-digital.")
+    LOGGER.info("[%s] Loading data into track-digital.", date)
     processing.run(date, ctx.obj.get('connection_string'))
-    LOGGER.info(f"[{date}] Data now loaded into track-digital.")
+    LOGGER.info("[%s] Data now loaded into track-digital.", date)
 
 
 @main.command(help="Populate DB with domains")

--- a/tracker/data/logger.py
+++ b/tracker/data/logger.py
@@ -4,9 +4,9 @@ import logging
 def unwrap_exception_message(exc: BaseException, join: str = " - ") -> str:
     if exc.__context__:
         if exc.args:
-            return f"{exc}{join}{unwrap_exception_message(exc.__context__)}"
-        return f"{unwrap_exception_message(exc.__context__)}"
-    return f"{exc}"
+            return "{exc}{join}{message}".format(exc=exc, join=join, message=unwrap_exception_message(exc.__context__))
+        return "{message}".format(message=unwrap_exception_message(exc.__context__))
+    return "{exc}".format(exc=exc)
 
 
 def get_logger(name: str) -> logging.Logger:


### PR DESCRIPTION
John brought to my attention that f-strings are new in 3.6, so our claim of "3.5+" is actually wrong with our use of them.

As such (and since they are not that important) I've refactored the few places we use them into using the string format method instead.